### PR TITLE
pref:lark bot support @user

### DIFF
--- a/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/starter/alarm/lark/LarkAlarmConstants.java
+++ b/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/starter/alarm/lark/LarkAlarmConstants.java
@@ -24,7 +24,19 @@ public class LarkAlarmConstants {
     public static final String NOTICE_JSON_PATH = "classpath:properties/lark/notice.json";
 
     /**
-     * lark at format
+     * lark at format. openid
+     * 当配置openid时,机器人可以@人
      */
-    public static final String LARK_AT_FORMAT = "<at email=''>%s</at>";
+    public static final String LARK_AT_FORMAT_OPENID = "<at id='%s'></at>";
+
+    /**
+     * lark at format. username
+     * 当配置username时,只能蓝色字体展示@username,被@人无@提醒
+     */
+    public static final String LARK_AT_FORMAT_USERNAME = "<at id=''>%s</at>";
+
+    /**
+     * lark openid prefix
+     */
+    public static final String LARK_OPENID_PREFIX = "ou_";
 }

--- a/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/starter/alarm/lark/LarkSendMessageHandler.java
+++ b/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/starter/alarm/lark/LarkSendMessageHandler.java
@@ -170,7 +170,8 @@ public class LarkSendMessageHandler implements SendMessageHandler {
             return "";
         }
         return Arrays.stream(notifyConfig.getReceives().split(","))
-                .map(receive -> String.format(LARK_AT_FORMAT, receive))
+                .map(receive -> StrUtil.startWith(receive, LARK_OPENID_PREFIX) ?
+                        String.format(LARK_AT_FORMAT_OPENID, receive) : String.format(LARK_AT_FORMAT_USERNAME, receive))
                 .collect(Collectors.joining(" "));
     }
 

--- a/hippo4j-spring-boot-starter/src/main/resources/properties/lark/alarm.json
+++ b/hippo4j-spring-boot-starter/src/main/resources/properties/lark/alarm.json
@@ -153,8 +153,8 @@
           {
             "is_short": true,
             "text": {
-              "user_id": "** OWNER：** %s",
-              "tag": "at"
+              "content": "** OWNER：** %s",
+              "tag": "lark_md"
             }
           },
           {


### PR DESCRIPTION
利用飞书文档 [Markdown模块](https://open.feishu.cn/document/ukTMukTMukTM/uADOwUjLwgDM14CM4ATN) 使lark bot支持@人，且支持根据配置的 `receives` 信息动态选择@openid还是@username。