### PR TITLE
配置文件未设置server.port时，DiscoveryConfiguration默认选择8080端口

### DIFF
--- a/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/starter/config/DiscoveryConfiguration.java
+++ b/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/starter/config/DiscoveryConfiguration.java
@@ -39,7 +39,7 @@ public class DiscoveryConfiguration {
     public InstanceInfo instanceConfig() {
         String namespace = properties.getNamespace();
         String itemId = properties.getItemId();
-        String port = environment.getProperty("server.port");
+        String port = environment.getProperty("server.port", "8080");
         String applicationName = environment.getProperty("spring.dynamic.thread-pool.item-id");
         String active = environment.getProperty("spring.profiles.active", "UNKNOWN");
 


### PR DESCRIPTION
配置文件未设置server.port，管理后台线程池实例模块页面
1. 实例标识显示异常，如：${ip}:null_xxxx
2. 操作栏点击查看、堆栈按钮提升失败
![image](https://user-images.githubusercontent.com/16870828/154638348-70742ec2-ee1f-44a5-8819-5cb5c93ac5f6.png)
