### PR TITLE
apollo动态配置不生效 #162

### DIFF
--- a/hippo4j-spring-boot/hippo4j-core-spring-boot-starter/src/main/java/cn/hippo4j/core/starter/refresher/ApolloRefresherHandler.java
+++ b/hippo4j-spring-boot/hippo4j-core-spring-boot-starter/src/main/java/cn/hippo4j/core/starter/refresher/ApolloRefresherHandler.java
@@ -35,7 +35,7 @@ public class ApolloRefresherHandler extends AbstractCoreThreadPoolDynamicRefresh
 
         ConfigChangeListener configChangeListener = configChangeEvent -> {
             ConfigFile configFile = ConfigService.getConfigFile(
-                    namespace,
+                    this.namespace.replaceAll("." + bootstrapCoreProperties.getConfigFileType().getValue(), ""),
                     ConfigFileFormat.fromString(bootstrapCoreProperties.getConfigFileType().getValue())
             );
 

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,20 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0-M1</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -297,20 +297,6 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.0-M1</version>
                 <configuration>


### PR DESCRIPTION
新版本需要配置如下
apollo:
    namespace: thread-pool.yml
    config-file-type: yml 